### PR TITLE
Add Greek language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Validators support default errorText messages in this languages:
 - Dutch (nl)
 - Farsi/Persian (fa)
 - French (fr)
+- Greek (el)  
 - German (de)
 - Hungarian (hu)
 - Indonesian (id)

--- a/lib/l10n/intl_el.arb
+++ b/lib/l10n/intl_el.arb
@@ -1,0 +1,114 @@
+{
+  "@@last_modified": "2020-06-19T21:53:39.706877",
+  "@@locale": "el",
+  "requiredErrorText": "Το πεδίο δεν μπορεί να είναι κενό.",
+  "@requiredErrorText": {
+    "description": "Error Text for required field",
+    "type": "text",
+    "placeholders": {}
+  },
+  "minErrorText": "Η τιμή πρέπει να είναι μεγαλύτερη ή ίση με {min}.",
+  "@minErrorText": {
+    "description": "Error Text for required field",
+    "type": "text",
+    "placeholders": {
+      "min": {}
+    }
+  },
+  "minLengthErrorText": "Η τιμή πρέπει να έχει μήκος μεγαλύτερο ή ίσο με {minLength}.",
+  "@minLengthErrorText": {
+    "description": "Error Text for required field",
+    "type": "text",
+    "placeholders": {
+      "minLength": {}
+    }
+  },
+  "maxErrorText": "Η τιμή πρέπει να είναι μικρότερη ή ίση με {max}.",
+  "@maxErrorText": {
+    "description": "Error Text for required field",
+    "type": "text",
+    "placeholders": {
+      "max": {}
+    }
+  },
+  "maxLengthErrorText": "Η τιμή πρέπει να έχει μήκος μικρότερο ή ίσο με {maxLength}.",
+  "@maxLengthErrorText": {
+    "description": "Error Text for required field",
+    "type": "text",
+    "placeholders": {
+      "maxLength": {}
+    }
+  },
+  "equalLengthErrorText": "Η τιμή πρέπει να έχει μήκος ίσο με {length}.",
+  "@equalLengthErrorText": {
+    "description": "Error Text for required field",
+    "type": "text",
+    "placeholders": {
+      "length": {}
+    }
+  },
+  "emailErrorText": "Το πεδίο πρέπει να έχει μία έγκυρη διεύθυνση email.",
+  "@emailErrorText": {
+    "description": "Error Text for email field",
+    "type": "text",
+    "placeholders": {}
+  },
+  "integerErrorText": "Η τιμή πρέπει να είναι ακέραιος αριθμό.",
+  "@integerErrorText": {
+    "description": "Error Text for integer validator",
+    "type": "text",
+    "placeholders": {}
+  },
+  "equalErrorText": "Η τιμή πρέπει να είναι ίση με {value}.",
+  "@equalErrorText": {
+    "description": "Error Text for equal validator",
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "notEqualErrorText": "Η τιμή δεν πρέπει να είναι ίση με {value}.",
+  "@notEqualErrorText": {
+    "description": "Error Text for not-equal validator",
+    "type": "text",
+    "placeholders": {
+      "value": {}
+    }
+  },
+  "urlErrorText": "Η τιμή πρέπει να είναι έγκυρη διεύθυνση URL.",
+  "@urlErrorText": {
+    "description": "Error Text for URL field",
+    "type": "text",
+    "placeholders": {}
+  },
+  "matchErrorText": "Η τιμή δεν ταιριάζει με το μοτίβο.",
+  "@matchErrorText": {
+    "description": "Error Text for pattern field",
+    "type": "text",
+    "placeholders": {}
+  },
+  "numericErrorText": "Η τιμή πρέπει να είναι αριθμητική.",
+  "@numericErrorText": {
+    "description": "Error Text for numeric field",
+    "type": "text",
+    "placeholders": {}
+  },
+  "creditCardErrorText": "Η τιμή πρέπει να είναι έγκυρη πιστωτική κάρτα.",
+  "@creditCardErrorText": {
+    "description": "Error Text for credit card field",
+    "type": "text",
+    "placeholders": {}
+  },
+  "ipErrorText": "Η τιμή πρέπει να είναι έγκυρη IP διεύθυνση.",
+  "@ipErrorText": {
+    "description": "Error Text for IP address field",
+    "type": "text",
+    "placeholders": {}
+  },
+  "dateStringErrorText": "Η τιμή πρέπει να είναι έγκυρη ημερομηνία.",
+  "@dateStringErrorText": {
+    "description": "Error Text for date string field",
+    "type": "text",
+    "placeholders": {}
+  }
+}

--- a/lib/localization/intl/messages.dart
+++ b/lib/localization/intl/messages.dart
@@ -11,6 +11,7 @@ import 'messages_bs.dart';
 import 'messages_ca.dart';
 import 'messages_cs.dart';
 import 'messages_de.dart';
+import 'messages_el.dart';
 import 'messages_en.dart';
 import 'messages_es.dart';
 import 'messages_et.dart';
@@ -125,6 +126,7 @@ abstract class FormBuilderLocalizationsImpl {
     Locale('ca'),
     Locale('cs'),
     Locale('de'),
+    Locale('el'),
     Locale('en'),
     Locale('es'),
     Locale('et'),
@@ -260,7 +262,7 @@ class _FormBuilderLocalizationsImplDelegate extends LocalizationsDelegate<FormBu
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['ar', 'bn', 'bs', 'ca', 'cs', 'de', 'en', 'es', 'et', 'fa', 'fr', 'hr', 'hu', 'id', 'it', 'ja', 'ko', 'lo', 'ms', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sw', 'ta', 'th', 'tr', 'uk', 'zh'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['ar', 'bn', 'bs', 'ca', 'cs', 'de', 'el', 'en', 'es', 'et', 'fa', 'fr', 'hr', 'hu', 'id', 'it', 'ja', 'ko', 'lo', 'ms', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sw', 'ta', 'th', 'tr', 'uk', 'zh'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_FormBuilderLocalizationsImplDelegate old) => false;
@@ -286,6 +288,7 @@ FormBuilderLocalizationsImpl lookupFormBuilderLocalizationsImpl(Locale locale) {
     case 'ca': return FormBuilderLocalizationsImplCa();
     case 'cs': return FormBuilderLocalizationsImplCs();
     case 'de': return FormBuilderLocalizationsImplDe();
+    case 'el': return FormBuilderLocalizationsImplEl();
     case 'en': return FormBuilderLocalizationsImplEn();
     case 'es': return FormBuilderLocalizationsImplEs();
     case 'et': return FormBuilderLocalizationsImplEt();

--- a/lib/localization/intl/messages_el.dart
+++ b/lib/localization/intl/messages_el.dart
@@ -1,0 +1,68 @@
+import 'messages.dart';
+
+/// The translations for Modern Greek (`el`).
+class FormBuilderLocalizationsImplEl extends FormBuilderLocalizationsImpl {
+  FormBuilderLocalizationsImplEl([String locale = 'el']) : super(locale);
+
+  @override
+  String get requiredErrorText => 'Το πεδίο δεν μπορεί να είναι κενό.';
+
+  @override
+  String minErrorText(Object min) {
+    return 'Η τιμή πρέπει να είναι μεγαλύτερη ή ίση με $min.';
+  }
+
+  @override
+  String minLengthErrorText(Object minLength) {
+    return 'Η τιμή πρέπει να έχει μήκος μεγαλύτερο ή ίσο με $minLength.';
+  }
+
+  @override
+  String maxErrorText(Object max) {
+    return 'Η τιμή πρέπει να είναι μικρότερη ή ίση με $max.';
+  }
+
+  @override
+  String maxLengthErrorText(Object maxLength) {
+    return 'Η τιμή πρέπει να έχει μήκος μικρότερο ή ίσο με $maxLength.';
+  }
+
+  @override
+  String equalLengthErrorText(Object length) {
+    return 'Η τιμή πρέπει να έχει μήκος ίσο με $length.';
+  }
+
+  @override
+  String get emailErrorText => 'Το πεδίο πρέπει να έχει μία έγκυρη διεύθυνση email.';
+
+  @override
+  String get integerErrorText => 'Η τιμή πρέπει να είναι ακέραιος αριθμό.';
+
+  @override
+  String equalErrorText(Object value) {
+    return 'Η τιμή πρέπει να είναι ίση με $value.';
+  }
+
+  @override
+  String notEqualErrorText(Object value) {
+    return 'Η τιμή δεν πρέπει να είναι ίση με $value.';
+  }
+
+  @override
+  String get urlErrorText => 'Η τιμή πρέπει να είναι έγκυρη διεύθυνση URL.';
+
+  @override
+  String get matchErrorText => 'Η τιμή δεν ταιριάζει με το μοτίβο.';
+
+  @override
+  String get numericErrorText => 'Η τιμή πρέπει να είναι αριθμητική.';
+
+  @override
+  String get creditCardErrorText => 'Η τιμή πρέπει να είναι έγκυρη πιστωτική κάρτα.';
+
+  @override
+  String get ipErrorText => 'Η τιμή πρέπει να είναι έγκυρη IP διεύθυνση.';
+
+  @override
+  String get dateStringErrorText => 'Η τιμή πρέπει να είναι έγκυρη ημερομηνία.';
+}


### PR DESCRIPTION
Added support for the Greek language.

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Read the [add new language guide](https://github.com/flutter-form-builder-ecosystem/form_builder_validators#add-new-supported-language)
- [x] Tested using the example app