### PR TITLE
#67 fix url case sensitivity

### DIFF
--- a/lib/src/utils/validators.dart
+++ b/lib/src/utils/validators.dart
@@ -10,6 +10,8 @@ RegExp _ipv6 =
 RegExp _creditCard = RegExp(
     r'^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})$');
 
+int _maxUrlLength = 2083;
+
 /// check if the string [str] is an email
 bool isEmail(String str) {
   return _email.hasMatch(str.toLowerCase());
@@ -32,7 +34,7 @@ bool isURL(String? str,
     List<String> hostBlacklist = const []}) {
   if (str == null ||
       str.isEmpty ||
-      str.length > 2083 ||
+      str.length > _maxUrlLength ||
       str.startsWith('mailto:')) {
     return false;
   }
@@ -43,7 +45,7 @@ bool isURL(String? str,
   // check protocol
   var split = str.split('://');
   if (split.length > 1) {
-    protocol = shift(split);
+    protocol = shift(split)!.toLowerCase();
     if (!protocols.contains(protocol)) {
       return false;
     }
@@ -94,7 +96,7 @@ bool isURL(String? str,
   // check hostname
   hostname = split.join('@');
   split = hostname.split(':');
-  host = shift(split)!;
+  host = shift(split)!.toLowerCase();
   if (split.isNotEmpty) {
     portStr = split.join(':');
     try {

--- a/test/form_builder_validators_test.dart
+++ b/test/form_builder_validators_test.dart
@@ -412,6 +412,11 @@ void main() {
             expect(validator('www.google.com'), isNull);
             expect(validator('google.com'), isNull);
             expect(validator('http://google.com'), isNull);
+            expect(validator('HTTPS://GOOGLE.COM'), isNull);
+            expect(validator('GOOGLE.com'), isNull);
+            expect(validator('GOOGLE.COM'), isNull);
+            expect(validator('google.com/search?q=TEST'), isNull);
+            expect(validator('google.com/search#MY_AWESOME_THING'), isNull);
             // Fail
             expect(validator('.com'), isNotNull);
             // Advanced overrides
@@ -456,4 +461,11 @@ void main() {
             expect(validator('1234'), isNotNull);
             expect(validator('ABC'), isNotNull);
           }));
+}
+
+class Test implements Comparable<Test> {
+  @override
+  int compareTo(Test other) {
+    throw UnimplementedError();
+  }
 }

--- a/test/form_builder_validators_test.dart
+++ b/test/form_builder_validators_test.dart
@@ -462,10 +462,3 @@ void main() {
             expect(validator('ABC'), isNotNull);
           }));
 }
-
-class Test implements Comparable<Test> {
-  @override
-  int compareTo(Test other) {
-    throw UnimplementedError();
-  }
-}


### PR DESCRIPTION
## Connection with issue(s)

Close #67

## Solution description

I added a `toLowercase` call for the split string before protocol check and before hostname check.

## Screenshots or Videos
_test should be enough_

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
