### PR TITLE
fix: remove numbers from special chars on username validator

### DIFF
--- a/lib/src/identity/username_validator.dart
+++ b/lib/src/identity/username_validator.dart
@@ -116,7 +116,7 @@ class UsernameValidator extends BaseValidator<String> {
     }
 
     if (!allowSpecialChar &&
-        RegExp(r'[!@#<>?":_`~;[\]\\|=+)(*&^%0-9-]').hasMatch(valueCandidate)) {
+        RegExp(r'[!@#<>?":_`~;[\]\\|=+)(*&^%-]').hasMatch(valueCandidate)) {
       return errorText != FormBuilderLocalizations.current.usernameErrorText
           ? errorText
           : FormBuilderLocalizations

--- a/test/src/identity/username_validator_test.dart
+++ b/test/src/identity/username_validator_test.dart
@@ -388,5 +388,21 @@ void main() {
       // Assert
       expect(result, FormBuilderLocalizations.current.usernameErrorText);
     });
+    test('should return null if the username meets all customized requirements',
+        () {
+      // Arrange
+      const UsernameValidator validator = UsernameValidator(
+        minLength: 4,
+        maxLength: 15,
+        allowNumbers: true,
+      );
+      const String validUsername = 'abc1';
+
+      // Act
+      final String? result = validator.validate(validUsername);
+
+      // Assert
+      expect(result, isNull);
+    });
   });
 }


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #114

## Solution description

Remove numbers from special chars on username validator

## To Do

- [X] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [X] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [X] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
