### PR TITLE
fix: support dynamic function callbacks in equal/notEqual validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,7 @@
 
 ## 8.4.0
 
-- Refactor l10n generator. Thanks [@ipcjs]()
+- Refactor l10n generator. Thanks [@ipcjs](https://github.com/ipcjs)
 - Add property to allow empty on equalLength validator. Thanks [@CircleCurve](https://github.com/CircleCurve)
 - Add support for more languages
   - Czech. Thanks [@edlman](https://github.com/flutter-form-builder-ecosystem/form_builder_validators/pull/3)

--- a/lib/src/core/equal_validator.dart
+++ b/lib/src/core/equal_validator.dart
@@ -25,12 +25,14 @@ class EqualValidator<T> extends TranslatedValidator<T> {
   /// The value to compare against.
   final Object value;
 
-  @override
-  String get translatedErrorText =>
-      FormBuilderLocalizations.current.equalErrorText(value.toString());
+  Object? get _resolvedValue =>
+      value is Function ? (value as Function)() : value;
 
   @override
-  String? validateValue(T valueCandidate) {
-    return valueCandidate != value ? errorText : null;
-  }
+  String get translatedErrorText => FormBuilderLocalizations.current
+      .equalErrorText(_resolvedValue?.toString() ?? '');
+
+  @override
+  String? validateValue(T valueCandidate) =>
+      valueCandidate != _resolvedValue ? errorText : null;
 }

--- a/lib/src/core/not_equal_validator.dart
+++ b/lib/src/core/not_equal_validator.dart
@@ -25,12 +25,14 @@ class NotEqualValidator<T> extends TranslatedValidator<T> {
   /// The value to compare against.
   final Object value;
 
-  @override
-  String get translatedErrorText =>
-      FormBuilderLocalizations.current.notEqualErrorText(value.toString());
+  Object? get _resolvedValue =>
+      value is Function ? (value as Function)() : value;
 
   @override
-  String? validateValue(T valueCandidate) {
-    return valueCandidate == value ? errorText : null;
-  }
+  String get translatedErrorText => FormBuilderLocalizations.current
+      .notEqualErrorText(_resolvedValue?.toString() ?? '');
+
+  @override
+  String? validateValue(T valueCandidate) =>
+      valueCandidate == _resolvedValue ? errorText : null;
 }

--- a/test/src/core/equal_validator_test.dart
+++ b/test/src/core/equal_validator_test.dart
@@ -172,5 +172,25 @@ void main() {
         expect(result, customErrorMessage);
       },
     );
+
+    test('should support dynamic function callbacks for comparison value', () {
+      // Arrange
+      String dynamicTarget = 'initial';
+      final EqualValidator<String> validator = EqualValidator<String>(
+        () => dynamicTarget,
+        errorText: customErrorMessage,
+      );
+
+      // Act & Assert 1: Matches initial
+      expect(validator.validate('initial'), isNull);
+      expect(validator.validate('changed'), customErrorMessage);
+
+      // Act: Update dynamicTarget
+      dynamicTarget = 'changed';
+
+      // Act & Assert 2: Now matches changed, not initial
+      expect(validator.validate('changed'), isNull);
+      expect(validator.validate('initial'), customErrorMessage);
+    });
   });
 }

--- a/test/src/core/not_equal_validator_test.dart
+++ b/test/src/core/not_equal_validator_test.dart
@@ -180,5 +180,25 @@ void main() {
         );
       },
     );
+
+    test('should support dynamic function callbacks for comparison value', () {
+      // Arrange
+      String dynamicTarget = 'initial';
+      final NotEqualValidator<String> validator = NotEqualValidator<String>(
+        () => dynamicTarget,
+        errorText: customErrorMessage,
+      );
+
+      // Act & Assert 1: Fails matching initial
+      expect(validator.validate('initial'), customErrorMessage);
+      expect(validator.validate('changed'), isNull);
+
+      // Act: Update dynamicTarget
+      dynamicTarget = 'changed';
+
+      // Act & Assert 2: Now fails matching changed, not initial
+      expect(validator.validate('changed'), customErrorMessage);
+      expect(validator.validate('initial'), isNull);
+    });
   });
 }


### PR DESCRIPTION
## Connection with issue(s)

Close #63

## Solution description

This PR updates the `EqualValidator` and `NotEqualValidator` classes to support dynamic comparison targets. 

When you pass an argument to these validators (e.g., `FormBuilderValidators.equal(password)`), it is evaluated once during the parent widget's build tree execution. If the target field changes later (such as a password field during registration), the confirmation field's validator remains stuck on the stale initial value unless a full state rebuild is triggered.

### Changes:
1. Modified `EqualValidator` and `NotEqualValidator` to inspect if the comparison `value` is a `Function`. If it is, the validator evaluates it dynamically at validation runtime (using `(value as Function)()`) instead of statically.
2. Extracted the resolution check to a private getter `_resolvedValue` and refactored validation methods using expression bodies.
3. Added type annotations to satisfy the strict static analyzer rules of the package.
4. Added new test suites in `test/src/core/equal_validator_test.dart` and `test/src/core/not_equal_validator_test.dart` confirming dynamic callbacks validate properly when comparison targets are updated.

## Screenshots or Videos

*(Not applicable — pure logic / functional package change)*

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme

---

## Test Verification Output

All **984 unit tests** passed successfully under static analyzer rules (`fvm flutter analyze` and `fvm flutter test`).

<details>
<summary><b>Click to expand unit test run logs</b></summary>

```text
Analyzing form_builder_validators-fix-63...                     
No issues found! (ran in 2.2s)

00:01 +121: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/equal_validator_test.dart: EqualValidator - should return null if the value is equal to the specified value
00:01 +122: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/equal_validator_test.dart: EqualValidator - should return error if the value is not equal to the specified value
00:01 +123: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/equal_validator_test.dart: EqualValidator - should return null if the numeric value is equal to the specified value
00:01 +124: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/equal_validator_test.dart: EqualValidator - should return error if the numeric value is not equal to the specified value
00:01 +125: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/equal_validator_test.dart: EqualValidator - should return error if the value is null and null check is enabled
00:01 +126: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/equal_validator_test.dart: EqualValidator - should return null if the value is null and null check is disabled
00:01 +127: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/equal_validator_test.dart: EqualValidator - should return null if the value is empty and null check is disabled
00:01 +128: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/equal_validator_test.dart: EqualValidator - should return error if the value is empty and null check is enabled
00:01 +129: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/equal_validator_test.dart: EqualValidator - should return custom error message if the value is not equal to the specified value
00:01 +130: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/equal_validator_test.dart: EqualValidator - should support dynamic function callbacks for comparison value
00:02 +162: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should return null if the value is not equal to the specified value
00:02 +165: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should return null if the value is null and null check is disabled
00:02 +166: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should return null if the value is null and null check is disabled
00:02 +169: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should return null if the integer value is not equal to the specified value
00:02 +171: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should return errorText if the integer value is equal to the specified value
00:02 +172: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should return errorText if the integer value is equal to the specified value
00:02 +175: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should return errorText if the double value is equal to the specified value
00:02 +177: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should return null if the list value is not equal to the specified value
00:02 +179: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should return errorText if the list value is equal to the specified value
00:02 +180: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should return errorText if the list value is equal to the specified value
00:02 +181: /Users/ghag23/Community/form_builder_validators-fix-63/test/src/core/not_equal_validator_test.dart: NotEqualValidator - should support dynamic function callbacks for comparison value
...
00:13 +984: All tests passed!
```
</details>
